### PR TITLE
Implement fetch_disk_usage

### DIFF
--- a/apps/client/lib/metric.ex
+++ b/apps/client/lib/metric.ex
@@ -38,7 +38,39 @@ defmodule Metric do
   end
 
   def fetch_disk_usage do
-    :disk
+    percentage_to_number = fn(percentage) ->
+      percentage
+      |> String.slice(0, String.length(percentage)-1)
+      |> String.to_integer
+    end
+
+    {output, status} = System.cmd("df", ["-P", "-k", "/"])
+
+    case {output, status} do
+      {output, 0} ->
+        [headers | disk_infos] =
+          output
+          |> String.trim
+          |> String.split("\n")
+          |> Enum.map(&String.split/1)
+
+        disk_infos
+        # "on" is truncated in header "Mounted on", so key is "Mounted"
+        |> Enum.map(fn(x) -> Enum.zip(headers, x) |> Map.new end)
+        |> Enum.map(
+          # values are negative when info not exist
+          fn(disk_info) ->
+            disk_info
+            |> Map.update("1024-blocks", -1, &String.to_integer/1)
+            |> Map.update("Used", -1, &String.to_integer/1)
+            |> Map.update("Available", -1, &String.to_integer/1)
+            |> Map.update("Capacity", -1, percentage_to_number)
+          end
+        )
+
+      {_, _} ->
+        []
+    end
   end
 
   def fetch_network_usage do


### PR DESCRIPTION
`df -P -k /` 명령을 파싱함.
대부분의 클라이언트/서버에서는 `/`로 충분하지만 `sherry`같은 서버에서는 원하는 정보를 못 가져올 수도 있음